### PR TITLE
Bluetooth: Fix to add SSR clean during disable timeout

### DIFF
--- a/include/hardware/bluetooth.h
+++ b/include/hardware/bluetooth.h
@@ -448,6 +448,9 @@ typedef struct {
     /** Closes the interface. */
     void (*cleanup)(void);
 
+    /** SSR cleanup. */
+    void (*ssrcleanup)(void);
+
     /** Get all Bluetooth Adapter properties at init */
     int (*get_adapter_properties)(void);
 


### PR DESCRIPTION
Fix for BT fails to turn on after several hours of test
Issue is due to disable timeout, host fails to get the wack ACK from
the SoC during BT turn of. Adding ssr cleanup routine in disable
timout routine

Change-Id: Iaa9c7750c96224c9df923291d7dad2b2417cdad3
CRs-Fixed: 614585
