### PR TITLE
fix: memory leak

### DIFF
--- a/modules/usbaudio/audio_hw.c
+++ b/modules/usbaudio/audio_hw.c
@@ -1037,6 +1037,8 @@ static int adev_set_parameters(struct audio_hw_device *dev, const char *kvpairs)
         }
     }
 
+    str_parms_destroy(parms);
+
     return 0;
 }
 


### PR DESCRIPTION
free momory for str_parms to prevent memory leak.

Change-Id: I7df5567d665554dbd4646c881f0f48b0c568c5fe
